### PR TITLE
move wait group counter

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,8 +52,8 @@ var rootCmd = &cobra.Command{
 		var wg sync.WaitGroup
 		maxOpenFilesLimitBuffer := make(chan int, maxOpenFileLimit)
 		for _, arg := range args {
-			go worker(arg, &wg, maxOpenFilesLimitBuffer)
 			wg.Add(1)
+			go worker(arg, &wg, maxOpenFilesLimitBuffer)
 		}
 
 		wg.Wait()


### PR DESCRIPTION
Wait group counter should run before the go routine

https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/sync/waitgroup.go;drc=ee833ed72e8ccfdd2193b0e6c0223ee8eb99b380;l=38

If the counter is added later, then we might run into a panic situation or do done which might decrease counter and then later add the counter which will lead to deadlock waiting forever